### PR TITLE
Cspec update

### DIFF
--- a/features/generate.feature
+++ b/features/generate.feature
@@ -181,6 +181,7 @@ Feature: GENERATE new environment yml file
       # count           The number of components in the load balance pool
       # compute         Size of compute resource to assign, defined in the compute.yml file
       # network         vlan the component nodes are attached
+      # cspec           The name of any customization specification to apply
       #
       # Additionally, you must specify IP addresses for each node. The generate
       # command will create array placeholders based on the default Count

--- a/lib/elevage/environment.rb
+++ b/lib/elevage/environment.rb
@@ -42,7 +42,7 @@ module Elevage
     # Returns multiline string = IP, fqdn, runlist
     # @return [String] Expanded node list
     def list_nodes
-      nodes =  @vcenter['destfolder'].to_s + "\n"
+      nodes = @vcenter['destfolder'].to_s + "\n"
       @components.each do |component, _config|
         (1..@components[component]['count']).each do |i|
           nodes += @components[component]['addresses'][i - 1].ljust(18, ' ') +

--- a/lib/elevage/provisioner.rb
+++ b/lib/elevage/provisioner.rb
@@ -181,6 +181,9 @@ module Elevage
       knife_cmd << " --ssh-user #{@options['ssh-user']}"
       knife_cmd << " --identity-file '#{@options['ssh-key']}'"
 
+      # customization spec if it exists
+      if @component['cspec'] then knife_cmd << " --cspec #{@component['cspec']}" end
+
       # What the node should be identified as in Chef
       nodename = String.new(@name)
       nodename << @vcenter['domain'] if @vcenter['appenddomain']

--- a/lib/elevage/provisioner.rb
+++ b/lib/elevage/provisioner.rb
@@ -124,7 +124,7 @@ module Elevage
       knife_cmd << " --regex #{@vcenter['datastore']}"
 
       # get result and clean up
-      @options['dry-run'] ? @vcenter['datastore'] : `#{knife_cmd}`.to_s.gsub!("\n", '')
+      @options['dry-run'] ? @vcenter['datastore'] : `#{knife_cmd}`.to_s.delete!("\n", '')
     end
     # rubocop:enable LineLength
 
@@ -182,7 +182,7 @@ module Elevage
       knife_cmd << " --identity-file '#{@options['ssh-key']}'"
 
       # customization spec if it exists
-      if @component['cspec'] then knife_cmd << " --cspec #{@component['cspec']}" end
+      knife_cmd << " --cspec #{@component['cspec']}" if @component['cspec']
 
       # What the node should be identified as in Chef
       nodename = String.new(@name)

--- a/lib/elevage/templates/environment.yml.tt
+++ b/lib/elevage/templates/environment.yml.tt
@@ -10,6 +10,7 @@ environment:
   # count           The number of components in the load balance pool
   # compute         Size of compute resource to assign, defined in the compute.yml file
   # network         vlan the component nodes are attached
+  # cspec           The name of any customization specification to apply
   #
   # Additionally, you must specify IP addresses for each node. The generate
   # command will create array placeholders based on the default Count

--- a/lib/elevage/version.rb
+++ b/lib/elevage/version.rb
@@ -1,4 +1,4 @@
 # simple gem version number tracking
 module Elevage
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
To provision a windows vm, we require the customization specification (cspec) parameter with the `knife vmsphere clone` call.